### PR TITLE
Support AJAX requests

### DIFF
--- a/loggedin.php
+++ b/loggedin.php
@@ -37,16 +37,14 @@ if ( ! class_exists( 'Loggedin' ) ) {
 		dirname( plugin_basename( __FILE__ ) ) . '/languages/'
 	);
 
-	// Only execute if not admin side.
-	if ( ! is_admin() ) {
-		require dirname( __FILE__ ) . '/includes/class-loggedin.php';
-		new Loggedin();
-	}
-
-	// Only execute if admin side
-	if ( is_admin() ) {
+	if ( is_admin() && ! wp_doing_ajax() ) {
+		// Only execute if admin side
 		require dirname( __FILE__ ) . '/includes/class-loggedin-admin.php';
 		new Loggedin_Admin();
+	}else{
+		// Only execute if not admin side and ajax calls.	
+		require dirname( __FILE__ ) . '/includes/class-loggedin.php';
+		new Loggedin();
 	}
 }
 


### PR DESCRIPTION
Hi, thank you for your great and well coded plugin. I'm trying to use it with my custom ajax login plugin but it doesn't work. 

The problem I have (and as I can see others have this issue too) is that you are requiring the Loggedin class only if `! is(admin)` is true. That function returns true also if you are doing an AJAX request, so for that type of requests the result is that the wp_authenticate_user filter is never hooked.

With this change the AJAX requests are also valid. Tested and works ;D.

Tell me if I can do anything else or change the pull request as you want. As it's the plugin's main file I suppose you will change the version number, but I don't know which one is the next you want to put...